### PR TITLE
docs: Simplify Hot Reload approach and add Documentation-First rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,43 @@ This is a plugin-based media synchronization platform with a layered architectur
 - `SyncState`: Tracks synchronization progress per service
 - `ServiceHealth`: Health monitoring and status reporting
 
+## Documentation-First Development
+
+### Plan-Document-Implement Rule
+
+**MANDATORY**: All design changes must follow this exact sequence:
+
+1. **Plan**: Make design decision or re-plan architecture
+2. **Document**: Immediately update CLAUDE.md/IMPLEMENTATION_ROADMAP.md
+3. **Implement**: Code according to updated documentation
+
+### Documentation Debt Prevention
+
+- **Never implement before documenting**: Documentation updates are not optional
+- **Commit documentation changes first**: Use git to track the reasoning
+- **Update impact analysis**: Document how changes affect other phases
+- **Immediate consistency**: No gaps between planning and documentation
+
+### Examples
+
+**✅ Correct Process**:
+```bash
+# 1. PLAN: Decide to re-phase 2.3 → 2.2.2.x
+# 2. DOCUMENT: Update IMPLEMENTATION_ROADMAP.md immediately
+git add IMPLEMENTATION_ROADMAP.md
+git commit -m "docs: Re-phase 2.3 Hot Reload as 2.2.2.x cycles"
+# 3. IMPLEMENT: Code according to updated plan
+```
+
+**❌ Wrong Process**:
+```bash
+# Implement first, document later - NEVER DO THIS
+git commit -m "feat: Implement hot reload"  # Implementation first
+# Later: "Oh, I should update the docs..." - TOO LATE
+```
+
+This rule prevents architectural drift and ensures team alignment.
+
 ## TDD Guidelines
 
 This project uses GitHub Flow with TDD cycles:

--- a/IMPLEMENTATION_ROADMAP.md
+++ b/IMPLEMENTATION_ROADMAP.md
@@ -319,19 +319,19 @@ EOF
 
 ### 2.2 Plugin Lifecycle Management (Days 10-12)
 
-**Key TDD Cycles**:
-1. Plugin loading and initialization
-2. Plugin unloading and cleanup
-3. Plugin health checks
-4. Error recovery and isolation
+**Phase 2.2.1: Core Lifecycle (Completed)**
+- Plugin loading and initialization
+- Plugin unloading and cleanup  
+- Plugin health checks
+- Error recovery and isolation
 
 ### 2.3 Hot Reload System (Days 13-14)
 
-**Key TDD Cycles**:
-1. File system watching
-2. Plugin reload without service interruption
-3. Configuration change propagation
-4. Rollback on reload failure
+**Simple Hot Reload Approach**:
+- Direct PluginManager integration with basic fsnotify
+- Configuration file watching without complex FileWatcher component
+- Minimal reload mechanism with existing plugin lifecycle
+- Focus on simplicity over feature completeness
 
 ### Phase 2 Quality Gates
 


### PR DESCRIPTION
## Summary
- Remove complex FileWatcher component (400+ lines)
- Simplify Phase 2.3 to direct PluginManager integration
- Add Documentation-First Development rules to prevent future over-engineering

## Background
The previous FileWatcher implementation was over-engineered for a simple config reload requirement. This PR:
1. Reverts the complex implementation 
2. Documents a simpler approach
3. Establishes rules to prevent similar over-engineering

## Changes
- **CLAUDE.md**: Added Plan-Document-Implement rule
- **IMPLEMENTATION_ROADMAP.md**: Simplified Phase 2.3 approach
- **Removed**: Complex FileWatcher component and related files

🤖 Generated with [Claude Code](https://claude.ai/code)